### PR TITLE
Christoph/feature/fix 06 productservice slot collision

### DIFF
--- a/contracts/services/ProductService.sol
+++ b/contracts/services/ProductService.sol
@@ -7,8 +7,8 @@ import "@etherisc/gif-interface/contracts/modules/ILicense.sol";
 
 import "@openzeppelin/contracts/utils/Context.sol";
 
-contract ProductService is 
-    WithRegistry, 
+contract ProductService is
+    WithRegistry,
     // CoreController
     Context
  {
@@ -17,28 +17,22 @@ contract ProductService is
     // solhint-disable-next-line no-empty-blocks
     constructor(address _registry) WithRegistry(_registry) {}
 
-    event LogProductServiceDebug1();
-    event LogProductServiceDebug2();
-
     fallback() external {
-        emit LogProductServiceDebug1();
 
         (uint256 id, bool isAuthorized, address policyFlow) = _license().getAuthorizationStatus(_msgSender());
-
-        emit LogProductServiceDebug2();
 
         require(isAuthorized, "ERROR:PRS-001:NOT_AUTHORIZED");
         require(policyFlow != address(0),"ERROR:PRS-002:POLICY_FLOW_NOT_RESOLVED");
 
         _delegate(policyFlow);
     }
-    
+
 
     /**
      * @dev Delegates the current call to `implementation`.
      *
      * This function does not return to its internal call site, it will return directly to the external caller.
-     * This function is a 1:1 copy of _delegate from 
+     * This function is a 1:1 copy of _delegate from
      * https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v4.6/contracts/proxy/Proxy.sol
      */
     function _delegate(address implementation) internal {
@@ -65,7 +59,7 @@ contract ProductService is
             }
         }
     }
-    
+
     function _license() internal view returns (ILicense) {
         return ILicense(registry.getContract("License"));
     }

--- a/contracts/shared/WithRegistry.sol
+++ b/contracts/shared/WithRegistry.sol
@@ -4,7 +4,14 @@ pragma solidity ^0.8.0;
 import "@etherisc/gif-interface/contracts/modules/IRegistry.sol";
 
 contract WithRegistry {
-    IRegistry public registry;
+
+/*
+ *  We can consider the registry address as immutable here as it contains the
+ *  root data structure for the whole GIF Instance.
+ *  We can therefore ensure that a policy flow cannot overwrite the address
+ *  neither by chance nor by intention.
+ */
+    IRegistry public immutable registry;
 
     modifier onlyInstanceOperator() {
         require(

--- a/contracts/shared/WithRegistry.sol
+++ b/contracts/shared/WithRegistry.sol
@@ -64,10 +64,6 @@ contract WithRegistry {
         registry = IRegistry(_registry);
     }
 
-    function assignRegistry(address _registry) external onlyInstanceOperator {
-        registry = IRegistry(_registry);
-    }
-
     function getContractFromRegistry(bytes32 _contractName)
         public
         // override

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etherisc/gif-contracts",
-  "version": "2.0.0-staging-a",
+  "version": "2.0.0-staging-l",
   "description": "This repository holds the GIF core contracts and tools to develop, test and deploy GIF instances.",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etherisc/gif-contracts",
-  "version": "v1.5.0-staging-k",
+  "version": "2.0.0-staging-a",
   "description": "This repository holds the GIF core contracts and tools to develop, test and deploy GIF instances.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
We follow the recommendation of the Solidified team and make the `registry` variable immutable.
`assignRegistry` needs to be removed, however, it is not used anyway.